### PR TITLE
restore aeon to 'scry-request' response wire

### DIFF
--- a/urbit/lib/sss.hoon
+++ b/urbit/lib/sss.hoon
@@ -59,9 +59,9 @@
     |=  which=[ship dude paths]
     ^-  (quip card:agent:gall subs)
     ?+  flow=(~(get by sub) which)  `0/sub
-      ~                 [~[(pine which)] 0/(~(put by sub) which ~)]
-      [~ ~]             [~[(pine which)] 0/sub]
-      [~ ~ [* %& * *]]  [~[(pine which)] 0/sub]
+      ~                 [~[(pine ~ which)] 0/(~(put by sub) which ~)]
+      [~ ~]             [~[(pine ~ which)] 0/sub]
+      [~ ~ [* %& * *]]  [~[(pine `+(aeon.u.u.flow) which)] 0/sub]
     ==
   ++  quit  (corl (lead %0) ~(del by sub))   ::  Unsub from [ship dude path].
   ++  read                                   ::  See current subscribed states.
@@ -138,9 +138,10 @@
   ::  Non-public facing arms below
   ::
   ++  pine
-    |=  [who=ship which=dude where=paths]
+    |=  [when=(unit aeon) who=ship which=dude where=paths]
     ^-  card:agent:gall
-    :*  %pass   (zoom scry-request/(scot %p who)^which^where)
+    =/  when  ?~  when  ~  (scot %ud u.when)
+    :*  %pass   (zoom scry-request/(scot %p who)^which^when^where)
         %agent  [who which]
         %poke   sss-to-pub/[result-type `result`[where dap.bowl]]
     ==


### PR DESCRIPTION
During the ames ack migration (10d60611249fcf0fc7b96e691e4be4a68a247f42), the `aeon` parameter was removed from the [`scry-request` response wire](https://github.com/wicrum-wicrun/sss/commit/10d60611249fcf0fc7b96e691e4be4a68a247f42#diff-31db9c15853b44e2fbb6909ac206fae747b5e382c73e67b712565fc17dfeeaa6L162-R132), which inadvertently caused `app/simple.hoon` to reference [unused agent paths](https://github.com/wicrum-wicrun/sss/blob/86a2d49bd9b483f582625e1ca185f4e4517f70f7/urbit/app/simple.hoon#L474-L482).

The [existing signature for `+tell:da`](https://github.com/wicrum-wicrun/sss/blob/86a2d49bd9b483f582625e1ca185f4e4517f70f7/urbit/lib/sss.hoon#L88-L89), which also expects the `aeon` parameter for a `scry-request`, suggests that this omission was unintentional. This PR simply restores the `aeon` in this wire with the values it used prior to 10d60611249fcf0fc7b96e691e4be4a68a247f42.

To test the correctness of this fix, I ran the following test case on two fake ships `~zod` and `~nec` with the SSS desk installed as `%simple`:

```
>> ~zod
> :simple &add 1
>> ~nec
> :simple &surf-sum [~zod %sum %foo ~]
```

Diffing the `dojo` outputs before and after the inclusion of this fix yields the following:

```
$ diff log-old.txt log-new.txt
31c31,32
< %simple: on-agent on wire //sss/scry-request/~zod/simple/sum/foo, %poke-ack
---
> %simple: on-agent on wire //sss/scry-request/~zod/simple//sum/foo, %poke-ack
> >   "sub-sum is: ~"
```

The fact that [the `sub-sum is:` line](https://github.com/wicrum-wicrun/sss/blob/86a2d49bd9b483f582625e1ca185f4e4517f70f7/urbit/app/simple.hoon#L481) is now being printed after the `scry-request` response suggests that the fix is working. Feel free to let me know if there are any other tests cases I should run to verify correctness.